### PR TITLE
Dynamically find APK and Mapping for Coeus

### DIFF
--- a/.github/workflows/android_code_quality.yml
+++ b/.github/workflows/android_code_quality.yml
@@ -171,6 +171,8 @@ jobs:
         run:
           |
             apk=$(find ${{ github.workspace }}/${{ inputs.appModule }}/build/outputs/apk/ -name '.apk')
+            echo ${{ github.workspace }}/${{ inputs.appModule }}/build/outputs/apk/
+            echo $apk
             echo "apk=$apk" >> $GITHUB_OUTPUT
       - name: Docker login for Azure registry
         id: coeus-docker-login

--- a/.github/workflows/android_code_quality.yml
+++ b/.github/workflows/android_code_quality.yml
@@ -220,4 +220,4 @@ jobs:
         id: coeus-check-fail
         if: ${{ fromJSON(inputs.runCoeus) }}
         run: |
-          echo '${{ env.COEUS_OUTPUT }}' | ! grep '\[ERROR\]'
+          echo '${{ env.COEUS_OUTPUT }}' | (! grep '\[ERROR\]')

--- a/.github/workflows/android_code_quality.yml
+++ b/.github/workflows/android_code_quality.yml
@@ -166,7 +166,11 @@ jobs:
         uses: gradle/gradle-build-action@v2.2.0
         with:
           arguments: :${{ inputs.appModule }}:assemble${{ steps.vars.outputs.flavor_capitalized }}Release ${{ steps.vars.outputs.gradle_properties }} --daemon
-
+      - name: Find APK
+        run:
+          |
+            apk=$(find ${{ github.workspace }}/${{ inputs.appModule }}/build/outputs/apk/ -name '.apk')
+            echo ::set-output name=apk::$apk
       - name: Docker login for Azure registry
         id: coeus-docker-login
         if: ${{ fromJSON(inputs.runCoeus) }}
@@ -175,7 +179,6 @@ jobs:
           login-server: ${{ secrets.ACR_REGISTRY }}
           username: ${{ secrets.ACR_USERNAME }}
           password: ${{ secrets.ACR_PASSWORD }}
-
       - name: Run Coeus
         id: coeus
         if: ${{ fromJSON(inputs.runCoeus) }}
@@ -183,7 +186,7 @@ jobs:
         # and https://github.community/t/set-output-truncates-multiline-strings/16852/
         # Don't fail CI here, print comment first.
         run: |
-          OUTPUT=`docker run -i -v ${{ github.workspace }}/${{ inputs.appModule }}/build/outputs/mapping/${{ inputs.flavor }}Release/mapping.txt:/home/coeus/mapping.txt -v ${{ github.workspace }}/${{ inputs.appModule }}/build/outputs/apk/${{ inputs.flavor }}/release/package-${{ inputs.flavor }}-release.apk:/home/coeus/check-apk.apk ubique.azurecr.io/coeus-docker || true`
+          OUTPUT=`docker run -i -v ${{ github.workspace }}/${{ inputs.appModule }}/build/outputs/mapping/${{ inputs.flavor }}Release/mapping.txt:/home/coeus/mapping.txt -v ${{ steps.vars.outputs.apk }}:/home/coeus/check-apk.apk ubique.azurecr.io/coeus-docker || true`
           echo "$OUTPUT" >> $GITHUB_STEP_SUMMARY
           echo "COEUS_OUTPUT<<EOF" >> $GITHUB_ENV
           echo "$OUTPUT" >> $GITHUB_ENV

--- a/.github/workflows/android_code_quality.yml
+++ b/.github/workflows/android_code_quality.yml
@@ -218,5 +218,5 @@ jobs:
         id: coeus-check-fail
         if: ${{ fromJSON(inputs.runCoeus) }}
         run: |
-          echo "${{ env.COEUS_OUTPUT }} | grep '[ERROR]'"
+          echo "${{ env.COEUS_OUTPUT }}" | grep '[ERROR]'
           if [ $? -ne 0 ]; then true; else false; fi

--- a/.github/workflows/android_code_quality.yml
+++ b/.github/workflows/android_code_quality.yml
@@ -167,10 +167,11 @@ jobs:
         with:
           arguments: :${{ inputs.appModule }}:assemble${{ steps.vars.outputs.flavor_capitalized }}Release ${{ steps.vars.outputs.gradle_properties }} --daemon
       - name: Find APK
+        id: find-apk
         run:
           |
             apk=$(find ${{ github.workspace }}/${{ inputs.appModule }}/build/outputs/apk/ -name '.apk')
-            echo ::set-output name=apk::$apk
+            echo "apk=$apk" >> $GITHUB_OUTPUT
       - name: Docker login for Azure registry
         id: coeus-docker-login
         if: ${{ fromJSON(inputs.runCoeus) }}
@@ -186,7 +187,7 @@ jobs:
         # and https://github.community/t/set-output-truncates-multiline-strings/16852/
         # Don't fail CI here, print comment first.
         run: |
-          OUTPUT=`docker run -i -v ${{ github.workspace }}/${{ inputs.appModule }}/build/outputs/mapping/${{ inputs.flavor }}Release/mapping.txt:/home/coeus/mapping.txt -v ${{ steps.vars.outputs.apk }}:/home/coeus/check-apk.apk ubique.azurecr.io/coeus-docker || true`
+          OUTPUT=`docker run -i -v ${{ github.workspace }}/${{ inputs.appModule }}/build/outputs/mapping/${{ inputs.flavor }}Release/mapping.txt:/home/coeus/mapping.txt -v ${{ steps.find-apk.outputs.apk }}:/home/coeus/check-apk.apk ubique.azurecr.io/coeus-docker || true`
           echo "$OUTPUT" >> $GITHUB_STEP_SUMMARY
           echo "COEUS_OUTPUT<<EOF" >> $GITHUB_ENV
           echo "$OUTPUT" >> $GITHUB_ENV

--- a/.github/workflows/android_code_quality.yml
+++ b/.github/workflows/android_code_quality.yml
@@ -166,12 +166,14 @@ jobs:
         uses: gradle/gradle-build-action@v2.2.0
         with:
           arguments: :${{ inputs.appModule }}:assemble${{ steps.vars.outputs.flavor_capitalized }}Release ${{ steps.vars.outputs.gradle_properties }} --daemon
-      - name: Find APK
+      - name: Find APK and Mapping
         id: find-apk
         run:
           |
             apk=`find ${{ github.workspace }}/${{ inputs.appModule }}/build/outputs/apk/ -name '*.apk'`
+            mapping=`find ${{ github.workspace }}/${{ inputs.appModule }}/build/outputs/mapping/ -name 'mapping.txt'`
             echo "apk=$apk" >> $GITHUB_OUTPUT
+            echo "mapping=$mapping" >> $GITHUB_OUTPUT
       - name: Docker login for Azure registry
         id: coeus-docker-login
         if: ${{ fromJSON(inputs.runCoeus) }}
@@ -187,7 +189,7 @@ jobs:
         # and https://github.community/t/set-output-truncates-multiline-strings/16852/
         # Don't fail CI here, print comment first.
         run: |
-          OUTPUT=`docker run -i -v ${{ github.workspace }}/${{ inputs.appModule }}/build/outputs/mapping/${{ inputs.flavor }}Release/mapping.txt:/home/coeus/mapping.txt -v ${{ steps.find-apk.outputs.apk }}:/home/coeus/check-apk.apk ubique.azurecr.io/coeus-docker || true`
+          OUTPUT=`docker run -i -v ${{ steps.find-apk.outputs.mapping }}:/home/coeus/mapping.txt -v ${{ steps.find-apk.outputs.apk }}:/home/coeus/check-apk.apk ubique.azurecr.io/coeus-docker || true`
           echo "$OUTPUT" >> $GITHUB_STEP_SUMMARY
           echo "COEUS_OUTPUT<<EOF" >> $GITHUB_ENV
           echo "$OUTPUT" >> $GITHUB_ENV

--- a/.github/workflows/android_code_quality.yml
+++ b/.github/workflows/android_code_quality.yml
@@ -171,9 +171,6 @@ jobs:
         run:
           |
             apk=`find ${{ github.workspace }}/${{ inputs.appModule }}/build/outputs/apk/ -name '*.apk'`
-            echo ${{ github.workspace }}/${{ inputs.appModule }}/build/outputs/apk/
-            echo `find ${{ github.workspace }}/${{ inputs.appModule }}/build/outputs/apk/ -name '*.apk'`
-            echo $apk
             echo "apk=$apk" >> $GITHUB_OUTPUT
       - name: Docker login for Azure registry
         id: coeus-docker-login
@@ -221,5 +218,5 @@ jobs:
         id: coeus-check-fail
         if: ${{ fromJSON(inputs.runCoeus) }}
         run: |
-          echo "${{ env.COEUS_OUTPUT }} | grep "[ERROR]"
+          echo "${{ env.COEUS_OUTPUT }} | grep '[ERROR]'"
           if [ $? -ne 0 ]; then true; else false; fi

--- a/.github/workflows/android_code_quality.yml
+++ b/.github/workflows/android_code_quality.yml
@@ -220,5 +220,5 @@ jobs:
         id: coeus-check-fail
         if: ${{ fromJSON(inputs.runCoeus) }}
         run: |
-          echo '${{ env.COEUS_OUTPUT }}' | grep '[ERROR]'
+          echo '${{ env.COEUS_OUTPUT }}' | grep '\[ERROR\]'
           if [ $? -ne 0 ]; then true; else false; fi

--- a/.github/workflows/android_code_quality.yml
+++ b/.github/workflows/android_code_quality.yml
@@ -220,5 +220,4 @@ jobs:
         id: coeus-check-fail
         if: ${{ fromJSON(inputs.runCoeus) }}
         run: |
-          echo '${{ env.COEUS_OUTPUT }}' | grep '\[ERROR\]'
-          if [ $? -ne 0 ]; then true; else false; fi
+          echo '${{ env.COEUS_OUTPUT }}' | ! grep '\[ERROR\]'

--- a/.github/workflows/android_code_quality.yml
+++ b/.github/workflows/android_code_quality.yml
@@ -220,5 +220,5 @@ jobs:
         id: coeus-check-fail
         if: ${{ fromJSON(inputs.runCoeus) }}
         run: |
-          echo "${{ env.COEUS_OUTPUT }}" | grep '[ERROR]'
+          echo '${{ env.COEUS_OUTPUT }}' | grep '[ERROR]'
           if [ $? -ne 0 ]; then true; else false; fi

--- a/.github/workflows/android_code_quality.yml
+++ b/.github/workflows/android_code_quality.yml
@@ -170,9 +170,9 @@ jobs:
         id: find-apk
         run:
           |
-            apk=`find ${{ github.workspace }}/${{ inputs.appModule }}/build/outputs/apk/ -name '.apk'`
+            apk=`find ${{ github.workspace }}/${{ inputs.appModule }}/build/outputs/apk/ -name '*.apk'`
             echo ${{ github.workspace }}/${{ inputs.appModule }}/build/outputs/apk/
-            echo `find ${{ github.workspace }}/${{ inputs.appModule }}/build/outputs/apk/ -name '.apk'`
+            echo `find ${{ github.workspace }}/${{ inputs.appModule }}/build/outputs/apk/ -name '*.apk'`
             echo $apk
             echo "apk=$apk" >> $GITHUB_OUTPUT
       - name: Docker login for Azure registry

--- a/.github/workflows/android_code_quality.yml
+++ b/.github/workflows/android_code_quality.yml
@@ -170,8 +170,9 @@ jobs:
         id: find-apk
         run:
           |
-            apk=$(find ${{ github.workspace }}/${{ inputs.appModule }}/build/outputs/apk/ -name '.apk')
+            apk=`find ${{ github.workspace }}/${{ inputs.appModule }}/build/outputs/apk/ -name '.apk'`
             echo ${{ github.workspace }}/${{ inputs.appModule }}/build/outputs/apk/
+            echo `find ${{ github.workspace }}/${{ inputs.appModule }}/build/outputs/apk/ -name '.apk'`
             echo $apk
             echo "apk=$apk" >> $GITHUB_OUTPUT
       - name: Docker login for Azure registry


### PR DESCRIPTION
We use the find command to dynamically find the APK, and the mapping file. This helps us to adjust to other projects, using different naming schemes for their build products.

Further, the check if the action fails was fixed. Before, depending on the output of Coeus, various shell expansions were applied. We now put the Coeus output into single quotes to suppress shell expansions of anykind.

Next, the grep command was interpreting the brackets as a character class instead of a full text match. To fix this, we escape the brackets.

Last but not least, the actions use the `-e` flag, which forces the script to abort as soon as an error is encountered. We now removed the check for the exit code of grep (1 if nothing was found, 0 if something was found), and instead use the inverted exit code (0 if nothing was found, 1 if something was found) to let the action fail.