### PR TITLE
Never fail if mapping directory is missing

### DIFF
--- a/.github/workflows/android_code_quality.yml
+++ b/.github/workflows/android_code_quality.yml
@@ -176,7 +176,7 @@ jobs:
         run:
           |
             apk=`find ${{ github.workspace }}/${{ inputs.appModule }}/build/outputs/apk/ -name '*.apk'`
-            mapping=`find ${{ github.workspace }}/${{ inputs.appModule }}/build/outputs/mapping/ -name 'mapping.txt'`
+            mapping=`find ${{ github.workspace }}/${{ inputs.appModule }}/build/outputs/mapping/ -name 'mapping.txt' || true`
             echo "apk=$apk" >> $GITHUB_OUTPUT
             echo "mapping=$mapping" >> $GITHUB_OUTPUT
       - name: Docker login for Azure registry


### PR DESCRIPTION
The find command will fail, if we try to search a directory that does not exist. Since we don't need a mapping file for coeus to work, we just ignore any errors on find for the mapping file.