### PR TITLE
Update workflow runner tags

### DIFF
--- a/.github/workflows/android_code_quality.yml
+++ b/.github/workflows/android_code_quality.yml
@@ -135,7 +135,7 @@ jobs:
   coeus:
     if: ${{ github.event_name == 'pull_request' && fromJSON(inputs.runCoeus) }}
     name: Run coeus binary analysis
-    runs-on: [self-hosted, linux]
+    runs-on: [self-hosted, linux, stable]
     timeout-minutes: 60
     concurrency:
       # Cancel any previous runs that have not yet finished for this workflow and git ref


### PR DESCRIPTION
Wir haben jetzt einen `stable`  Tag auf unseren Runners im Büro. Damit wird verhindert, dass Jobs auf dem falschen Runner laufen wenn wir andere Runner deployen.