### PR TITLE
Adapt actions for new k8s-based runners and run on circleCI images

### DIFF
--- a/.github/workflows/android_build_ubdiag_upload.yml
+++ b/.github/workflows/android_build_ubdiag_upload.yml
@@ -124,9 +124,9 @@ jobs:
           path: |
             ~/.gradle/caches
             ~/.gradle/wrapper
-          key: ${{ runner.os }}-${{ inputs.projectKey }}-gradle-${{ hashFiles('**/*.gradle*', '**/gradle-wrapper.properties') }}
+          key: cimg-android-${{ inputs.projectKey }}-gradle-${{ hashFiles('**/*.gradle*', '**/gradle-wrapper.properties') }}
           restore-keys: |
-            ${{ runner.os }}-${{ inputs.projectKey }}-gradle-
+            cimg-android-${{ inputs.projectKey }}-gradle-
 
       # Setup the build environment with Gradle
       - name: Build app

--- a/.github/workflows/android_build_ubdiag_upload.yml
+++ b/.github/workflows/android_build_ubdiag_upload.yml
@@ -150,7 +150,7 @@ jobs:
 
       # Upload to UBDiag
       - name: Upload build to UBDiag
-        uses: UbiqueInnovation/ubdiag-upload-action@new-runners
+        uses: UbiqueInnovation/ubdiag-upload-action@v1.1.2
         with:
           buildNumber: ${{ github.run_number }}
           projectKey: ${{ inputs.projectKey }}

--- a/.github/workflows/android_build_ubdiag_upload.yml
+++ b/.github/workflows/android_build_ubdiag_upload.yml
@@ -107,6 +107,9 @@ jobs:
           distribution: "zulu"
           java-version: "17"
 
+      - name: Install zstd
+        run: sudo apt-get install -y zstd
+
       - name: Cache Maven packages on self-hosted MinIO
         uses: tespkg/actions-cache@v1.7.1
         with:

--- a/.github/workflows/android_build_ubdiag_upload.yml
+++ b/.github/workflows/android_build_ubdiag_upload.yml
@@ -110,7 +110,7 @@ jobs:
       - name: Install zstd
         run: sudo apt-get install -y zstd
 
-      - name: Cache Maven packages on self-hosted MinIO
+      - name: Cache Gradle packages on self-hosted MinIO
         uses: tespkg/actions-cache@v1.7.1
         with:
           endpoint: ${{ inputs.self_hosted_cache_endpoint }}

--- a/.github/workflows/android_build_ubdiag_upload.yml
+++ b/.github/workflows/android_build_ubdiag_upload.yml
@@ -68,9 +68,9 @@ on:
 jobs:
   build:
     name: Build ${{ inputs.flavor }} Flavor
-    runs-on: ["new-runners"]
+    runs-on: ["dind"]
     container:
-      image: cimg/android
+      image: cimg/android:2024.04.1
     defaults:
       run:
         working-directory: ${{ inputs.workingDirectory }}
@@ -85,16 +85,17 @@ jobs:
         uses: actions/checkout@v4.1.1
         with:
           token: ${{ secrets.ANDROID_JENKINS_PAT }}
-          submodules: 'recursive'
-          lfs: 'true'
+          submodules: "recursive"
+          lfs: "true"
 
       # Set build variables for reuse in multiple steps
       - name: Set Build Variables
         id: vars
+        shell: bash
         run: |
           flavor=${{ inputs.flavor }}
           buildUuid=$(cat /proc/sys/kernel/random/uuid)
-          webIconPath=${{ github.workspace }}/${{ inputs.workingDirectory }}/${{ inputs.appModule }}/tmp_icon_large_for_backend.png
+          webIconPath=$GITHUB_WORKSPACE/${{ inputs.workingDirectory }}/${{ inputs.appModule }}/tmp_icon_large_for_backend.png
           echo "build_uuid=$buildUuid" >> "$GITHUB_OUTPUT"
           echo "web_icon=$webIconPath" >> "$GITHUB_OUTPUT"
           echo "flavor_capitalized=${flavor~}" >> "$GITHUB_OUTPUT"
@@ -146,7 +147,7 @@ jobs:
 
       # Upload to UBDiag
       - name: Upload build to UBDiag
-        uses: UbiqueInnovation/ubdiag-upload-action@v1.1.1
+        uses: UbiqueInnovation/ubdiag-upload-action@new-runners
         with:
           buildNumber: ${{ github.run_number }}
           projectKey: ${{ inputs.projectKey }}

--- a/.github/workflows/android_build_ubdiag_upload.yml
+++ b/.github/workflows/android_build_ubdiag_upload.yml
@@ -15,19 +15,19 @@ on:
       appModule:
         type: string
         required: false
-        default: "app"
+        default: 'app'
       concurrencyGroup:
         type: string
         required: false
         default: ${{ github.workflow }}-${{ github.ref }}
       workingDirectory:
         type: string
-        default: "./"
+        default: './'
         required: false
-        description: "The working directory of the script, for projects where the gradle project is not in the root folder. Must end with a slash."
+        description: 'The working directory of the script, for projects where the gradle project is not in the root folder. Must end with a slash.'
       self_hosted_cache_endpoint:
         required: false
-        default: "truenas.local.lan"
+        default: 'truenas.local.lan'
         type: string
         description: Should be set for selfhosted builds, but build won't fail without it
       self_hosted_cache_port:
@@ -68,7 +68,7 @@ on:
 jobs:
   build:
     name: Build ${{ inputs.flavor }} Flavor
-    runs-on: ["k8s-runner"]
+    runs-on: ['k8s-runner']
     container:
       image: cimg/android:2024.04.1
     defaults:
@@ -85,8 +85,8 @@ jobs:
         uses: actions/checkout@v4.1.1
         with:
           token: ${{ secrets.ANDROID_JENKINS_PAT }}
-          submodules: "recursive"
-          lfs: "true"
+          submodules: 'recursive'
+          lfs: 'true'
 
       # Set build variables for reuse in multiple steps
       - name: Set Build Variables
@@ -104,8 +104,8 @@ jobs:
       - name: Set up JDK
         uses: actions/setup-java@v4.2.1
         with:
-          distribution: "zulu"
-          java-version: "17"
+          distribution: 'zulu'
+          java-version: '17'
 
       - name: Install zstd
         run: sudo apt-get install -y zstd
@@ -156,7 +156,7 @@ jobs:
           projectKey: ${{ inputs.projectKey }}
           flavor: ${{ inputs.flavor }}
           app: ${{ inputs.app }}
-          appModuleDirectory: "${{ inputs.workingDirectory }}${{ inputs.appModule }}"
+          appModuleDirectory: '${{ inputs.workingDirectory }}${{ inputs.appModule }}'
           buildUuid: ${{ steps.vars.outputs.build_uuid }}
           webIconFile: tmp_icon_large_for_backend.png
           backendEndpoint: ${{ secrets.UBDIAG_UPLOAD_URL }}

--- a/.github/workflows/android_build_ubdiag_upload.yml
+++ b/.github/workflows/android_build_ubdiag_upload.yml
@@ -68,7 +68,7 @@ on:
 jobs:
   build:
     name: Build ${{ inputs.flavor }} Flavor
-    runs-on: ["dind"]
+    runs-on: ["k8s-runner"]
     container:
       image: cimg/android:2024.04.1
     defaults:

--- a/.github/workflows/android_build_ubdiag_upload.yml
+++ b/.github/workflows/android_build_ubdiag_upload.yml
@@ -15,33 +15,33 @@ on:
       appModule:
         type: string
         required: false
-        default: 'app'
+        default: "app"
       concurrencyGroup:
         type: string
         required: false
         default: ${{ github.workflow }}-${{ github.ref }}
       workingDirectory:
         type: string
-        default: './'
+        default: "./"
         required: false
-        description: 'The working directory of the script, for projects where the gradle project is not in the root folder. Must end with a slash.'
+        description: "The working directory of the script, for projects where the gradle project is not in the root folder. Must end with a slash."
       self_hosted_cache_endpoint:
-          required: false
-          default: 'truenas.local.lan'
-          type: string
-          description: Should be set for selfhosted builds, but build won't fail without it
+        required: false
+        default: "truenas.local.lan"
+        type: string
+        description: Should be set for selfhosted builds, but build won't fail without it
       self_hosted_cache_port:
-          required: false
-          default: 9000
-          type: number
+        required: false
+        default: 9000
+        type: number
       self_hosted_cache_bucket:
-          required: false
-          default: github-actions-cache
-          type: string
+        required: false
+        default: github-actions-cache
+        type: string
       self_hosted_cache_region:
-          required: false
-          default: local
-          type: string
+        required: false
+        default: local
+        type: string
     secrets:
       ANDROID_JENKINS_PAT:
         required: true
@@ -68,7 +68,9 @@ on:
 jobs:
   build:
     name: Build ${{ inputs.flavor }} Flavor
-    runs-on: ["self-hosted", "linux", "stable"]
+    runs-on: ["new-runners"]
+    container:
+      image: cimg/android
     defaults:
       run:
         working-directory: ${{ inputs.workingDirectory }}
@@ -101,26 +103,26 @@ jobs:
       - name: Set up JDK
         uses: actions/setup-java@v4.2.1
         with:
-          distribution: 'zulu'
-          java-version: '17'
+          distribution: "zulu"
+          java-version: "17"
 
-      -   name: Cache Maven packages on self-hosted MinIO
-          uses: tespkg/actions-cache@v1.7.1
-          with:
-              endpoint: ${{ inputs.self_hosted_cache_endpoint }}
-              port: ${{ inputs.self_hosted_cache_port }}
-              insecure: true
-              accessKey: ${{ secrets.self_hosted_cache_access_key }}
-              secretKey: ${{ secrets.self_hosted_cache_secret_key }}
-              bucket: ${{ inputs.self_hosted_cache_bucket }}
-              region: ${{ inputs.self_hosted_cache_region }}
-              use-fallback: true
-              path: |
-                ~/.gradle/caches
-                ~/.gradle/wrapper
-              key: ${{ runner.os }}-${{ inputs.projectKey }}-gradle-${{ hashFiles('**/*.gradle*', '**/gradle-wrapper.properties') }}
-              restore-keys: |
-                ${{ runner.os }}-${{ inputs.projectKey }}-gradle-
+      - name: Cache Maven packages on self-hosted MinIO
+        uses: tespkg/actions-cache@v1.7.1
+        with:
+          endpoint: ${{ inputs.self_hosted_cache_endpoint }}
+          port: ${{ inputs.self_hosted_cache_port }}
+          insecure: true
+          accessKey: ${{ secrets.self_hosted_cache_access_key }}
+          secretKey: ${{ secrets.self_hosted_cache_secret_key }}
+          bucket: ${{ inputs.self_hosted_cache_bucket }}
+          region: ${{ inputs.self_hosted_cache_region }}
+          use-fallback: true
+          path: |
+            ~/.gradle/caches
+            ~/.gradle/wrapper
+          key: ${{ runner.os }}-${{ inputs.projectKey }}-gradle-${{ hashFiles('**/*.gradle*', '**/gradle-wrapper.properties') }}
+          restore-keys: |
+            ${{ runner.os }}-${{ inputs.projectKey }}-gradle-
 
       # Setup the build environment with Gradle
       - name: Build app
@@ -141,7 +143,6 @@ jobs:
             ${{ secrets.ADDITIONAL_GRADLE_PROPS }}
         env:
           SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
-            
 
       # Upload to UBDiag
       - name: Upload build to UBDiag
@@ -151,7 +152,7 @@ jobs:
           projectKey: ${{ inputs.projectKey }}
           flavor: ${{ inputs.flavor }}
           app: ${{ inputs.app }}
-          appModuleDirectory: '${{ inputs.workingDirectory }}${{ inputs.appModule }}'
+          appModuleDirectory: "${{ inputs.workingDirectory }}${{ inputs.appModule }}"
           buildUuid: ${{ steps.vars.outputs.build_uuid }}
           webIconFile: tmp_icon_large_for_backend.png
           backendEndpoint: ${{ secrets.UBDIAG_UPLOAD_URL }}

--- a/.github/workflows/android_code_quality.yml
+++ b/.github/workflows/android_code_quality.yml
@@ -117,6 +117,24 @@ jobs:
           distribution: "zulu"
           java-version: "17"
 
+      - name: Cache Gradle packages on self-hosted MinIO
+        uses: tespkg/actions-cache@v1.7.1
+        with:
+          endpoint: ${{ inputs.self_hosted_cache_endpoint }}
+          port: ${{ inputs.self_hosted_cache_port }}
+          insecure: true
+          accessKey: ${{ secrets.self_hosted_cache_access_key }}
+          secretKey: ${{ secrets.self_hosted_cache_secret_key }}
+          bucket: ${{ inputs.self_hosted_cache_bucket }}
+          region: ${{ inputs.self_hosted_cache_region }}
+          use-fallback: true
+          path: |
+            ~/.gradle/caches
+            ~/.gradle/wrapper
+          key: cimg-android-${{ inputs.projectKey }}-gradle-${{ hashFiles('**/*.gradle*', '**/gradle-wrapper.properties') }}
+          restore-keys: |
+            cimg-android-${{ inputs.projectKey }}-gradle-
+
       - name: Cache SonarCloud packages on selfhosted MinIO
         if: ${{ fromJSON(inputs.runSonarqube) }}
         uses: tespkg/actions-cache@v1.7.1
@@ -207,6 +225,25 @@ jobs:
         with:
           distribution: "zulu"
           java-version: "17"
+
+      - name: Cache Gradle packages on self-hosted MinIO
+        uses: tespkg/actions-cache@v1.7.1
+        with:
+          endpoint: ${{ inputs.self_hosted_cache_endpoint }}
+          port: ${{ inputs.self_hosted_cache_port }}
+          insecure: true
+          accessKey: ${{ secrets.self_hosted_cache_access_key }}
+          secretKey: ${{ secrets.self_hosted_cache_secret_key }}
+          bucket: ${{ inputs.self_hosted_cache_bucket }}
+          region: ${{ inputs.self_hosted_cache_region }}
+          use-fallback: true
+          path: |
+            ~/.gradle/caches
+            ~/.gradle/wrapper
+          key: cimg-android-${{ inputs.projectKey }}-gradle-${{ hashFiles('**/*.gradle*', '**/gradle-wrapper.properties') }}
+          restore-keys: |
+            cimg-android-${{ inputs.projectKey }}-gradle-
+
       # Run Coeus
       - name: Assemble the APK for static code analysis
         id: coeus-assemble
@@ -229,8 +266,6 @@ jobs:
           login-server: ${{ secrets.ACR_REGISTRY }}
           username: ${{ secrets.ACR_USERNAME }}
           password: ${{ secrets.ACR_PASSWORD }}
-      - name: Setup tmate session
-        uses: mxschmitt/action-tmate@v3
 
       - name: Run Coeus
         id: coeus

--- a/.github/workflows/android_code_quality.yml
+++ b/.github/workflows/android_code_quality.yml
@@ -189,6 +189,7 @@ jobs:
       # Set build variables for reuse in multiple steps
       - name: Set Build Variables
         id: vars
+        shell: bash
         run: |
           flavor=${{ inputs.flavor }}
           echo "flavor_capitalized=${flavor~}" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/android_code_quality.yml
+++ b/.github/workflows/android_code_quality.yml
@@ -216,11 +216,12 @@ jobs:
           cache-disabled: true
       - name: Find APK and Mapping
         id: find-apk
+        shell: bash
         run: |
-          apk=`find $GITHUB_WORKSPACE/${{ inputs.appModule }}/build/outputs/apk/ -name '*.apk'`
-          mapping=`find $GITHUB_WORKSPACE/${{ inputs.appModule }}/build/outputs/mapping/ -name 'mapping.txt' || true`
-          echo "apk=$apk" >> $GITHUB_OUTPUT
-          echo "mapping=$mapping" >> $GITHUB_OUTPUT
+          export apk=`find $GITHUB_WORKSPACE/${{ inputs.appModule }}/build/outputs/apk/ -name '*.apk'`
+          export mapping=`find $GITHUB_WORKSPACE/${{ inputs.appModule }}/build/outputs/mapping/ -name 'mapping.txt' || true`
+          echo "apk=${apk//__w/home\/runner\/_work\/}" >> $GITHUB_OUTPUT
+          echo "mapping=${mapping//__w/home\/runner\/_work\/}" >> $GITHUB_OUTPUT
       - name: Docker login for Azure registry
         id: coeus-docker-login
         uses: azure/docker-login@v1

--- a/.github/workflows/android_code_quality.yml
+++ b/.github/workflows/android_code_quality.yml
@@ -86,6 +86,7 @@ jobs:
     runs-on: ["k8s-runner"]
     container:
       image: cimg/android:2024.04.1
+      options: "--group-add=123"
     timeout-minutes: 60
     concurrency:
       # Cancel any previous runs that have not yet finished for this workflow and git ref
@@ -175,7 +176,7 @@ jobs:
     name: Run coeus binary analysis
     runs-on: ["docker"]
     container:
-      image: cimg/android:2024.04.1
+      image: ghcr.io/actions/actions-runner:2.316.1
     timeout-minutes: 60
     concurrency:
       # Cancel any previous runs that have not yet finished for this workflow and git ref
@@ -199,6 +200,8 @@ jobs:
           echo "flavor_capitalized=${flavor~}" >> "$GITHUB_OUTPUT"
           export gradleProps="-PsentryAuthToken=${{ secrets.SENTRY_AUTH_TOKEN }} -PubiqueMavenUrl=${{ secrets.UB_ARTIFACTORY_URL_ANDROID }} -PubiqueMavenUser=${{ secrets.UB_ARTIFACTORY_USERNAME }} -PubiqueMavenPass=${{ secrets.UB_ARTIFACTORY_PASSWORD }} -PubiquePoEditorAPIKey=${{ secrets.UBIQUE_POEDITOR_API_KEY }} ${{ secrets.ADDITIONAL_GRADLE_PROPS }}"
           echo "gradle_properties=$gradleProps" >> "$GITHUB_OUTPUT"
+          sudo groupadd -g 123 dind
+          sudo usermod -aG dind circleci
 
       # Setup JDK environment
       - name: Set up JDK
@@ -207,8 +210,6 @@ jobs:
           distribution: "zulu"
           java-version: "17"
       # Run Coeus
-      - name: Setup tmate session
-        uses: mxschmitt/action-tmate@v3
       - name: Assemble the APK for static code analysis
         id: coeus-assemble
         uses: gradle/actions/setup-gradle@v3.1.0
@@ -229,6 +230,9 @@ jobs:
           login-server: ${{ secrets.ACR_REGISTRY }}
           username: ${{ secrets.ACR_USERNAME }}
           password: ${{ secrets.ACR_PASSWORD }}
+      - name: Setup tmate session
+        uses: mxschmitt/action-tmate@v3
+
       - name: Run Coeus
         id: coeus
         # See https://docs.github.com/en/actions/using-workflows/workflow-commands-for-github-actions#setting-an-environment-variable

--- a/.github/workflows/android_code_quality.yml
+++ b/.github/workflows/android_code_quality.yml
@@ -9,7 +9,7 @@ on:
       appModule:
         type: string
         required: false
-        default: "app"
+        default: 'app'
       runCoeus:
         type: boolean
         required: false
@@ -17,7 +17,7 @@ on:
       skipRules:
         type: string
         required: false
-        default: ""
+        default: ''
       runTests:
         type: boolean
         required: false
@@ -32,7 +32,7 @@ on:
         default: false
       self_hosted_cache_endpoint:
         required: false
-        default: "truenas.local.lan"
+        default: 'truenas.local.lan'
         type: string
         description: Should be set for selfhosted builds, but build won't fail without it
       self_hosted_cache_port:
@@ -83,7 +83,7 @@ on:
 jobs:
   code_quality:
     name: Run code quality checks
-    runs-on: ["k8s-runner"]
+    runs-on: ['k8s-runner']
     container:
       image: cimg/android:2024.04.1
     timeout-minutes: 60
@@ -97,8 +97,8 @@ jobs:
         uses: actions/checkout@v4.1.1
         with:
           token: ${{ secrets.ANDROID_JENKINS_PAT }}
-          submodules: "recursive"
-          lfs: "true"
+          submodules: 'recursive'
+          lfs: 'true'
 
       # Set build variables for reuse in multiple steps
       - name: Set Build Variables
@@ -114,8 +114,8 @@ jobs:
       - name: Set up JDK
         uses: actions/setup-java@v4.2.1
         with:
-          distribution: "zulu"
-          java-version: "17"
+          distribution: 'zulu'
+          java-version: '17'
 
       - name: Cache Gradle packages on self-hosted MinIO
         uses: tespkg/actions-cache@v1.7.1
@@ -186,15 +186,15 @@ jobs:
         if: ${{ fromJSON(inputs.runTests) && steps.tests.outcome == 'success' }}
         uses: EnricoMi/publish-unit-test-result-action@v1.36
         with:
-          check_name: "Unit Test Results"
+          check_name: 'Unit Test Results'
           files: ${{ inputs.appModule }}/build/test-results/**/*.xml
   coeus:
     #if: ${{ github.event_name == 'pull_request' && fromJSON(inputs.runCoeus) }}
     name: Run coeus binary analysis
-    runs-on: ["docker"]
+    runs-on: ['docker']
     container:
       image: cimg/android:2024.04.1
-      options: "--group-add=123"
+      options: '--group-add=123'
     timeout-minutes: 60
     concurrency:
       # Cancel any previous runs that have not yet finished for this workflow and git ref
@@ -206,8 +206,8 @@ jobs:
         uses: actions/checkout@v4.1.1
         with:
           token: ${{ secrets.ANDROID_JENKINS_PAT }}
-          submodules: "recursive"
-          lfs: "true"
+          submodules: 'recursive'
+          lfs: 'true'
 
       # Set build variables for reuse in multiple steps
       - name: Set Build Variables
@@ -223,8 +223,8 @@ jobs:
       - name: Set up JDK
         uses: actions/setup-java@v4.2.1
         with:
-          distribution: "zulu"
-          java-version: "17"
+          distribution: 'zulu'
+          java-version: '17'
 
       - name: Cache Gradle packages on self-hosted MinIO
         uses: tespkg/actions-cache@v1.7.1
@@ -285,8 +285,8 @@ jobs:
         uses: peter-evans/find-comment@1769778a0c5bd330272d749d12c036d65e70d39d
         with:
           issue-number: ${{ github.event.pull_request.number }}
-          comment-author: "github-actions[bot]"
-          body-includes: "Coeus Binary Analysis Results"
+          comment-author: 'github-actions[bot]'
+          body-includes: 'Coeus Binary Analysis Results'
 
       - name: Comment Coeus Output
         id: coeus-comment

--- a/.github/workflows/android_code_quality.yml
+++ b/.github/workflows/android_code_quality.yml
@@ -83,7 +83,9 @@ on:
 jobs:
   code_quality:
     name: Run code quality checks
-    runs-on: [self-hosted, linux, stable]
+    runs-on: ["k8s-runner"]
+    container:
+      image: cimg/android:2024.04.1
     timeout-minutes: 60
     concurrency:
       # Cancel any previous runs that have not yet finished for this workflow and git ref
@@ -95,8 +97,8 @@ jobs:
         uses: actions/checkout@v4.1.1
         with:
           token: ${{ secrets.ANDROID_JENKINS_PAT }}
-          submodules: 'recursive'
-          lfs: 'true'
+          submodules: "recursive"
+          lfs: "true"
 
       # Set build variables for reuse in multiple steps
       - name: Set Build Variables
@@ -165,9 +167,11 @@ jobs:
           check_name: "Unit Test Results"
           files: ${{ inputs.appModule }}/build/test-results/**/*.xml
   coeus:
-    if: ${{ github.event_name == 'pull_request' && fromJSON(inputs.runCoeus) }}
+    #if: ${{ github.event_name == 'pull_request' && fromJSON(inputs.runCoeus) }}
     name: Run coeus binary analysis
-    runs-on: [self-hosted, linux, stable]
+    runs-on: ["dind"]
+    container:
+      image: cimg/android:2024.04.1
     timeout-minutes: 60
     concurrency:
       # Cancel any previous runs that have not yet finished for this workflow and git ref

--- a/.github/workflows/android_code_quality.yml
+++ b/.github/workflows/android_code_quality.yml
@@ -9,7 +9,7 @@ on:
       appModule:
         type: string
         required: false
-        default: 'app'
+        default: "app"
       runCoeus:
         type: boolean
         required: false
@@ -17,7 +17,7 @@ on:
       skipRules:
         type: string
         required: false
-        default: ''
+        default: ""
       runTests:
         type: boolean
         required: false
@@ -31,23 +31,23 @@ on:
         required: false
         default: false
       self_hosted_cache_endpoint:
-          required: false
-          default: 'truenas.local.lan'
-          type: string
-          description: Should be set for selfhosted builds, but build won't fail without it
+        required: false
+        default: "truenas.local.lan"
+        type: string
+        description: Should be set for selfhosted builds, but build won't fail without it
       self_hosted_cache_port:
-          required: false
-          default: 9000
-          type: number
+        required: false
+        default: 9000
+        type: number
       self_hosted_cache_bucket:
-          required: false
-          default: github-actions-cache
-          type: string
+        required: false
+        default: github-actions-cache
+        type: string
       self_hosted_cache_region:
-          required: false
-          default: local
-          type: string
-  
+        required: false
+        default: local
+        type: string
+
     secrets:
       ANDROID_JENKINS_PAT:
         required: true
@@ -179,8 +179,8 @@ jobs:
         uses: actions/checkout@v4.1.1
         with:
           token: ${{ secrets.ANDROID_JENKINS_PAT }}
-          submodules: 'recursive'
-          lfs: 'true'
+          submodules: "recursive"
+          lfs: "true"
 
       # Set build variables for reuse in multiple steps
       - name: Set Build Variables
@@ -205,12 +205,11 @@ jobs:
           arguments: :${{ inputs.appModule }}:assemble${{ steps.vars.outputs.flavor_capitalized }}Release ${{ steps.vars.outputs.gradle_properties }} --daemon
       - name: Find APK and Mapping
         id: find-apk
-        run:
-          |
-            apk=`find ${{ github.workspace }}/${{ inputs.appModule }}/build/outputs/apk/ -name '*.apk'`
-            mapping=`find ${{ github.workspace }}/${{ inputs.appModule }}/build/outputs/mapping/ -name 'mapping.txt' || true`
-            echo "apk=$apk" >> $GITHUB_OUTPUT
-            echo "mapping=$mapping" >> $GITHUB_OUTPUT
+        run: |
+          apk=`find ${{ github.workspace }}/${{ inputs.appModule }}/build/outputs/apk/ -name '*.apk'`
+          mapping=`find ${{ github.workspace }}/${{ inputs.appModule }}/build/outputs/mapping/ -name 'mapping.txt' || true`
+          echo "apk=$apk" >> $GITHUB_OUTPUT
+          echo "mapping=$mapping" >> $GITHUB_OUTPUT
       - name: Docker login for Azure registry
         id: coeus-docker-login
         uses: azure/docker-login@v1

--- a/.github/workflows/android_code_quality.yml
+++ b/.github/workflows/android_code_quality.yml
@@ -103,10 +103,11 @@ jobs:
       # Set build variables for reuse in multiple steps
       - name: Set Build Variables
         id: vars
+        shell: bash
         run: |
-          flavor=${{ inputs.flavor }}
+          export flavor=${{ inputs.flavor }}
           echo "flavor_capitalized=${flavor~}" >> "$GITHUB_OUTPUT"
-          gradleProps="-PsentryAuthToken=${{ secrets.SENTRY_AUTH_TOKEN }} -PubiqueMavenUrl=${{ secrets.UB_ARTIFACTORY_URL_ANDROID }} -PubiqueMavenUser=${{ secrets.UB_ARTIFACTORY_USERNAME }} -PubiqueMavenPass=${{ secrets.UB_ARTIFACTORY_PASSWORD }} -PubiquePoEditorAPIKey=${{ secrets.UBIQUE_POEDITOR_API_KEY }} ${{ secrets.ADDITIONAL_GRADLE_PROPS }}"
+          export gradleProps="-PsentryAuthToken=${{ secrets.SENTRY_AUTH_TOKEN }} -PubiqueMavenUrl=${{ secrets.UB_ARTIFACTORY_URL_ANDROID }} -PubiqueMavenUser=${{ secrets.UB_ARTIFACTORY_USERNAME }} -PubiqueMavenPass=${{ secrets.UB_ARTIFACTORY_PASSWORD }} -PubiquePoEditorAPIKey=${{ secrets.UBIQUE_POEDITOR_API_KEY }} ${{ secrets.ADDITIONAL_GRADLE_PROPS }}"
           echo "gradle_properties=$gradleProps" >> "$GITHUB_OUTPUT"
 
       # Setup JDK environment
@@ -206,6 +207,8 @@ jobs:
           distribution: "zulu"
           java-version: "17"
       # Run Coeus
+      - name: Setup tmate session
+        uses: mxschmitt/action-tmate@v3
       - name: Assemble the APK for static code analysis
         id: coeus-assemble
         uses: gradle/actions/setup-gradle@v3.1.0

--- a/.github/workflows/android_code_quality.yml
+++ b/.github/workflows/android_code_quality.yml
@@ -218,8 +218,8 @@ jobs:
       - name: Find APK and Mapping
         id: find-apk
         run: |
-          apk=`find ${{ github.workspace }}/${{ inputs.appModule }}/build/outputs/apk/ -name '*.apk'`
-          mapping=`find ${{ github.workspace }}/${{ inputs.appModule }}/build/outputs/mapping/ -name 'mapping.txt' || true`
+          apk=`find $GITHUB_WORKSPACE/${{ inputs.appModule }}/build/outputs/apk/ -name '*.apk'`
+          mapping=`find $GITHUB_WORKSPACE/${{ inputs.appModule }}/build/outputs/mapping/ -name 'mapping.txt' || true`
           echo "apk=$apk" >> $GITHUB_OUTPUT
           echo "mapping=$mapping" >> $GITHUB_OUTPUT
       - name: Docker login for Azure registry

--- a/.github/workflows/android_code_quality.yml
+++ b/.github/workflows/android_code_quality.yml
@@ -139,6 +139,7 @@ jobs:
         uses: gradle/actions/setup-gradle@v3.1.0
         with:
           arguments: :${{ inputs.appModule }}:test${{ steps.vars.outputs.flavor_capitalized }}DebugUnitTest ${{ steps.vars.outputs.gradle_properties }} --daemon
+          cache-disabled: true
 
       # Run Android Lint checks
       - name: Run Lint
@@ -147,6 +148,7 @@ jobs:
         uses: gradle/actions/setup-gradle@v3.1.0
         with:
           arguments: :${{ inputs.appModule }}:lint${{ steps.vars.outputs.flavor_capitalized }}Debug ${{ steps.vars.outputs.gradle_properties }} --daemon
+          cache-disabled: true
 
       # Run Sonarqube code analysis
       - name: Run Sonarqube
@@ -158,6 +160,7 @@ jobs:
           SONAR_TOKEN: ${{ secrets.UBIQUE_SONAR_TOKEN }}
         with:
           arguments: :${{ inputs.appModule }}:sonarqube ${{ steps.vars.outputs.gradle_properties }} --daemon
+          cache-disabled: true
 
       # Publish test results to pull requests
       - name: Publish Unit Test Results
@@ -200,14 +203,15 @@ jobs:
       - name: Set up JDK
         uses: actions/setup-java@v4.2.1
         with:
-          distribution: 'zulu'
-          java-version: '17'
+          distribution: "zulu"
+          java-version: "17"
       # Run Coeus
       - name: Assemble the APK for static code analysis
         id: coeus-assemble
         uses: gradle/actions/setup-gradle@v3.1.0
         with:
           arguments: :${{ inputs.appModule }}:assemble${{ steps.vars.outputs.flavor_capitalized }}Release ${{ steps.vars.outputs.gradle_properties }} --daemon
+          cache-disabled: true
       - name: Find APK and Mapping
         id: find-apk
         run: |

--- a/.github/workflows/android_code_quality.yml
+++ b/.github/workflows/android_code_quality.yml
@@ -169,7 +169,7 @@ jobs:
   coeus:
     #if: ${{ github.event_name == 'pull_request' && fromJSON(inputs.runCoeus) }}
     name: Run coeus binary analysis
-    runs-on: ["dind"]
+    runs-on: ["docker"]
     container:
       image: cimg/android:2024.04.1
     timeout-minutes: 60
@@ -191,9 +191,9 @@ jobs:
         id: vars
         shell: bash
         run: |
-          flavor=${{ inputs.flavor }}
+          export flavor=${{ inputs.flavor }}
           echo "flavor_capitalized=${flavor~}" >> "$GITHUB_OUTPUT"
-          gradleProps="-PsentryAuthToken=${{ secrets.SENTRY_AUTH_TOKEN }} -PubiqueMavenUrl=${{ secrets.UB_ARTIFACTORY_URL_ANDROID }} -PubiqueMavenUser=${{ secrets.UB_ARTIFACTORY_USERNAME }} -PubiqueMavenPass=${{ secrets.UB_ARTIFACTORY_PASSWORD }} -PubiquePoEditorAPIKey=${{ secrets.UBIQUE_POEDITOR_API_KEY }} ${{ secrets.ADDITIONAL_GRADLE_PROPS }}"
+          export gradleProps="-PsentryAuthToken=${{ secrets.SENTRY_AUTH_TOKEN }} -PubiqueMavenUrl=${{ secrets.UB_ARTIFACTORY_URL_ANDROID }} -PubiqueMavenUser=${{ secrets.UB_ARTIFACTORY_USERNAME }} -PubiqueMavenPass=${{ secrets.UB_ARTIFACTORY_PASSWORD }} -PubiquePoEditorAPIKey=${{ secrets.UBIQUE_POEDITOR_API_KEY }} ${{ secrets.ADDITIONAL_GRADLE_PROPS }}"
           echo "gradle_properties=$gradleProps" >> "$GITHUB_OUTPUT"
 
       # Setup JDK environment

--- a/.github/workflows/android_code_quality.yml
+++ b/.github/workflows/android_code_quality.yml
@@ -189,7 +189,7 @@ jobs:
           check_name: 'Unit Test Results'
           files: ${{ inputs.appModule }}/build/test-results/**/*.xml
   coeus:
-    #if: ${{ github.event_name == 'pull_request' && fromJSON(inputs.runCoeus) }}
+    if: ${{ github.event_name == 'pull_request' && fromJSON(inputs.runCoeus) }}
     name: Run coeus binary analysis
     runs-on: ['docker']
     container:

--- a/.github/workflows/android_code_quality.yml
+++ b/.github/workflows/android_code_quality.yml
@@ -86,7 +86,6 @@ jobs:
     runs-on: ["k8s-runner"]
     container:
       image: cimg/android:2024.04.1
-      options: "--group-add=123"
     timeout-minutes: 60
     concurrency:
       # Cancel any previous runs that have not yet finished for this workflow and git ref
@@ -115,8 +114,8 @@ jobs:
       - name: Set up JDK
         uses: actions/setup-java@v4.2.1
         with:
-          distribution: 'zulu'
-          java-version: '17'
+          distribution: "zulu"
+          java-version: "17"
 
       - name: Cache SonarCloud packages on selfhosted MinIO
         if: ${{ fromJSON(inputs.runSonarqube) }}
@@ -176,7 +175,8 @@ jobs:
     name: Run coeus binary analysis
     runs-on: ["docker"]
     container:
-      image: ghcr.io/actions/actions-runner:2.316.1
+      image: cimg/android:2024.04.1
+      options: "--group-add=123"
     timeout-minutes: 60
     concurrency:
       # Cancel any previous runs that have not yet finished for this workflow and git ref
@@ -200,8 +200,6 @@ jobs:
           echo "flavor_capitalized=${flavor~}" >> "$GITHUB_OUTPUT"
           export gradleProps="-PsentryAuthToken=${{ secrets.SENTRY_AUTH_TOKEN }} -PubiqueMavenUrl=${{ secrets.UB_ARTIFACTORY_URL_ANDROID }} -PubiqueMavenUser=${{ secrets.UB_ARTIFACTORY_USERNAME }} -PubiqueMavenPass=${{ secrets.UB_ARTIFACTORY_PASSWORD }} -PubiquePoEditorAPIKey=${{ secrets.UBIQUE_POEDITOR_API_KEY }} ${{ secrets.ADDITIONAL_GRADLE_PROPS }}"
           echo "gradle_properties=$gradleProps" >> "$GITHUB_OUTPUT"
-          sudo groupadd -g 123 dind
-          sudo usermod -aG dind circleci
 
       # Setup JDK environment
       - name: Set up JDK


### PR DESCRIPTION
Wir haben jetzt auf dem office cluster die neuen k8s nativen Github actions runner. 
Damit kommen wir weg von unserem gebastelten runner image und können jobs jetzt auf den images von CircleCI laufen lassen.