### PR TITLE
allow to override branch name for alpaka upload

### DIFF
--- a/.github/workflows/android_build_alpaka_upload.yml
+++ b/.github/workflows/android_build_alpaka_upload.yml
@@ -10,6 +10,11 @@ on:
         type: string
         required: false
         default: 'app'
+      branchName:
+        type: string
+        required: false
+        default: ${{ github.ref_name }}
+        description: The branch name to use for Alpaka
       concurrencyGroup:
         type: string
         required: false
@@ -160,7 +165,7 @@ jobs:
             -Pbuild_batch=${{ steps.vars.outputs.build_batch }}
             -Pbuild_id=${{ steps.vars.outputs.build_id }}
             -Pbuild_number=${{ steps.vars.outputs.build_number }}
-            -Pbranch=${{ github.ref_name }}
+            -Pbranch=${{ inputs.branchName }}
             ${{ secrets.ADDITIONAL_GRADLE_PROPS }}
         env:
           SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}


### PR DESCRIPTION
This pull request includes changes to the `.github/workflows/android_build_alpaka_upload.yml` file to allow for more flexible branch naming in the Alpaka build process. The most important changes include adding a new input parameter for the branch name and updating the job configuration to use this new parameter.

Enhancements to branch name flexibility:

* [`.github/workflows/android_build_alpaka_upload.yml`](diffhunk://#diff-6860a4c132477e159ab5028e6e787af355d3e50d1d81984a837d1e351ec09031R13-R17): Added a new input parameter `branchName` with a default value of `${{ github.ref_name }}` to allow specifying the branch name for Alpaka.
* [`.github/workflows/android_build_alpaka_upload.yml`](diffhunk://#diff-6860a4c132477e159ab5028e6e787af355d3e50d1d81984a837d1e351ec09031L163-R168): Updated the job configuration to use the new `branchName` input parameter instead of the hardcoded `${{ github.ref_name }}`.