### PR TITLE
update runner tag  for android_library_artifactory

### DIFF
--- a/.github/workflows/android_library_artifactory.yml
+++ b/.github/workflows/android_library_artifactory.yml
@@ -42,7 +42,9 @@ on:
 jobs:
   build:
     name: Build library
-    runs-on: ["self-hosted", "linux", "stable"]
+    runs-on: ["k8s-runner"]
+    container:
+      image: cimg/android:2026.03.1-ndk
     defaults:
       run:
         working-directory: ${{ inputs.workingDirectory }}


### PR DESCRIPTION
die alten tags gibts nicht mehr