### PR TITLE
Limit Gradle workers on k8s jobs

### DIFF
--- a/.github/workflows/android_build_alpaka_upload.yml
+++ b/.github/workflows/android_build_alpaka_upload.yml
@@ -88,6 +88,8 @@ jobs:
   build:
     name: Build
     runs-on: ${{ fromJSON(inputs.runs-on) }}
+    env:
+      GRADLE_OPTS: "-Dorg.gradle.workers.max=8 -Dorg.gradle.daemon=false"
     container:
       image: cimg/android:${{ inputs.android-image-version }}
     defaults:
@@ -169,6 +171,8 @@ jobs:
     name: Upload
     needs: build
     runs-on: ${{ fromJSON(inputs.runs-on) }}
+    env:
+      GRADLE_OPTS: "-Dorg.gradle.workers.max=8 -Dorg.gradle.daemon=false"
     container:
       image: cimg/android:${{ inputs.android-image-version }}
     defaults:

--- a/.github/workflows/android_build_alpaka_upload.yml
+++ b/.github/workflows/android_build_alpaka_upload.yml
@@ -90,6 +90,7 @@ jobs:
     runs-on: ${{ fromJSON(inputs.runs-on) }}
     env:
       GRADLE_OPTS: "-Dorg.gradle.workers.max=8 -Dorg.gradle.daemon=false"
+      CMAKE_BUILD_PARALLEL_LEVEL: 8
       "ORG_GRADLE_PROJECT_kotlin.compiler.execution.strategy": "in-process"
     container:
       image: cimg/android:${{ inputs.android-image-version }}
@@ -174,6 +175,7 @@ jobs:
     runs-on: ${{ fromJSON(inputs.runs-on) }}
     env:
       GRADLE_OPTS: "-Dorg.gradle.workers.max=8 -Dorg.gradle.daemon=false"
+      CMAKE_BUILD_PARALLEL_LEVEL: 8
       "ORG_GRADLE_PROJECT_kotlin.compiler.execution.strategy": "in-process"
     container:
       image: cimg/android:${{ inputs.android-image-version }}

--- a/.github/workflows/android_build_alpaka_upload.yml
+++ b/.github/workflows/android_build_alpaka_upload.yml
@@ -90,6 +90,7 @@ jobs:
     runs-on: ${{ fromJSON(inputs.runs-on) }}
     env:
       GRADLE_OPTS: "-Dorg.gradle.workers.max=8 -Dorg.gradle.daemon=false"
+      "ORG_GRADLE_PROJECT_kotlin.compiler.execution.strategy": "in-process"
     container:
       image: cimg/android:${{ inputs.android-image-version }}
     defaults:
@@ -173,6 +174,7 @@ jobs:
     runs-on: ${{ fromJSON(inputs.runs-on) }}
     env:
       GRADLE_OPTS: "-Dorg.gradle.workers.max=8 -Dorg.gradle.daemon=false"
+      "ORG_GRADLE_PROJECT_kotlin.compiler.execution.strategy": "in-process"
     container:
       image: cimg/android:${{ inputs.android-image-version }}
     defaults:

--- a/.github/workflows/android_build_store_upload.yml
+++ b/.github/workflows/android_build_store_upload.yml
@@ -88,6 +88,7 @@ jobs:
     env:
       AAB_STAGING_DIR: .tmp/publishing_aab
       GRADLE_OPTS: "-Dorg.gradle.workers.max=8 -Dorg.gradle.daemon=false"
+      CMAKE_BUILD_PARALLEL_LEVEL: 8
       "ORG_GRADLE_PROJECT_kotlin.compiler.execution.strategy": "in-process"
     outputs:
       flavor-capitalized: ${{ steps.setup.outputs.flavor-capitalized }}
@@ -156,6 +157,7 @@ jobs:
     env:
       AAB_STAGING_DIR: .tmp/publishing_aab
       GRADLE_OPTS: "-Dorg.gradle.workers.max=8 -Dorg.gradle.daemon=false"
+      CMAKE_BUILD_PARALLEL_LEVEL: 8
       "ORG_GRADLE_PROJECT_kotlin.compiler.execution.strategy": "in-process"
     steps:
       - name: Setup Android environment

--- a/.github/workflows/android_build_store_upload.yml
+++ b/.github/workflows/android_build_store_upload.yml
@@ -87,6 +87,7 @@ jobs:
       cancel-in-progress: true
     env:
       AAB_STAGING_DIR: .tmp/publishing_aab
+      GRADLE_OPTS: "-Dorg.gradle.workers.max=8 -Dorg.gradle.daemon=false"
     outputs:
       flavor-capitalized: ${{ steps.setup.outputs.flavor-capitalized }}
       app-module-path: ${{ steps.setup.outputs.app-module-path }}
@@ -153,6 +154,7 @@ jobs:
     timeout-minutes: 30
     env:
       AAB_STAGING_DIR: .tmp/publishing_aab
+      GRADLE_OPTS: "-Dorg.gradle.workers.max=8 -Dorg.gradle.daemon=false"
     steps:
       - name: Setup Android environment
         uses: UbiqueInnovation/actions-android/.github/actions/android-app-setup@v2

--- a/.github/workflows/android_build_store_upload.yml
+++ b/.github/workflows/android_build_store_upload.yml
@@ -88,6 +88,7 @@ jobs:
     env:
       AAB_STAGING_DIR: .tmp/publishing_aab
       GRADLE_OPTS: "-Dorg.gradle.workers.max=8 -Dorg.gradle.daemon=false"
+      "ORG_GRADLE_PROJECT_kotlin.compiler.execution.strategy": "in-process"
     outputs:
       flavor-capitalized: ${{ steps.setup.outputs.flavor-capitalized }}
       app-module-path: ${{ steps.setup.outputs.app-module-path }}
@@ -155,6 +156,7 @@ jobs:
     env:
       AAB_STAGING_DIR: .tmp/publishing_aab
       GRADLE_OPTS: "-Dorg.gradle.workers.max=8 -Dorg.gradle.daemon=false"
+      "ORG_GRADLE_PROJECT_kotlin.compiler.execution.strategy": "in-process"
     steps:
       - name: Setup Android environment
         uses: UbiqueInnovation/actions-android/.github/actions/android-app-setup@v2

--- a/.github/workflows/android_code_quality.yml
+++ b/.github/workflows/android_code_quality.yml
@@ -92,6 +92,7 @@ jobs:
     runs-on: ${{ fromJSON(inputs.runs-on) }}
     env:
       GRADLE_OPTS: "-Dorg.gradle.workers.max=8"
+      CMAKE_BUILD_PARALLEL_LEVEL: 8
       "ORG_GRADLE_PROJECT_kotlin.compiler.execution.strategy": "in-process"
     container:
       image: cimg/android:${{ inputs.android-image-version }}

--- a/.github/workflows/android_code_quality.yml
+++ b/.github/workflows/android_code_quality.yml
@@ -92,6 +92,7 @@ jobs:
     runs-on: ${{ fromJSON(inputs.runs-on) }}
     env:
       GRADLE_OPTS: "-Dorg.gradle.workers.max=8"
+      "ORG_GRADLE_PROJECT_kotlin.compiler.execution.strategy": "in-process"
     container:
       image: cimg/android:${{ inputs.android-image-version }}
     timeout-minutes: 60

--- a/.github/workflows/android_code_quality.yml
+++ b/.github/workflows/android_code_quality.yml
@@ -90,6 +90,8 @@ jobs:
   code_quality:
     name: Run code quality checks
     runs-on: ${{ fromJSON(inputs.runs-on) }}
+    env:
+      GRADLE_OPTS: "-Dorg.gradle.workers.max=8"
     container:
       image: cimg/android:${{ inputs.android-image-version }}
     timeout-minutes: 60

--- a/.github/workflows/android_gradle_task.yml
+++ b/.github/workflows/android_gradle_task.yml
@@ -58,6 +58,8 @@ on:
 jobs:
   task:
     runs-on: ${{ fromJSON(inputs.runs-on) }}
+    env:
+      GRADLE_OPTS: "-Dorg.gradle.workers.max=8 -Dorg.gradle.daemon=false"
     container:
       image: cimg/android:${{ inputs.android-image-version }}
     defaults:

--- a/.github/workflows/android_gradle_task.yml
+++ b/.github/workflows/android_gradle_task.yml
@@ -60,6 +60,7 @@ jobs:
     runs-on: ${{ fromJSON(inputs.runs-on) }}
     env:
       GRADLE_OPTS: "-Dorg.gradle.workers.max=8 -Dorg.gradle.daemon=false"
+      "ORG_GRADLE_PROJECT_kotlin.compiler.execution.strategy": "in-process"
     container:
       image: cimg/android:${{ inputs.android-image-version }}
     defaults:

--- a/.github/workflows/android_gradle_task.yml
+++ b/.github/workflows/android_gradle_task.yml
@@ -60,6 +60,7 @@ jobs:
     runs-on: ${{ fromJSON(inputs.runs-on) }}
     env:
       GRADLE_OPTS: "-Dorg.gradle.workers.max=8 -Dorg.gradle.daemon=false"
+      CMAKE_BUILD_PARALLEL_LEVEL: 8
       "ORG_GRADLE_PROJECT_kotlin.compiler.execution.strategy": "in-process"
     container:
       image: cimg/android:${{ inputs.android-image-version }}

--- a/.github/workflows/android_library_artifactory.yml
+++ b/.github/workflows/android_library_artifactory.yml
@@ -65,6 +65,8 @@ jobs:
   build:
     name: Build library
     runs-on: ${{ fromJSON(inputs.runs-on) }}
+    env:
+      GRADLE_OPTS: "-Dorg.gradle.workers.max=8 -Dorg.gradle.daemon=false"
     container:
       image: cimg/android:${{ inputs.android-image-version }}
     defaults:

--- a/.github/workflows/android_library_artifactory.yml
+++ b/.github/workflows/android_library_artifactory.yml
@@ -67,6 +67,7 @@ jobs:
     runs-on: ${{ fromJSON(inputs.runs-on) }}
     env:
       GRADLE_OPTS: "-Dorg.gradle.workers.max=8 -Dorg.gradle.daemon=false"
+      "ORG_GRADLE_PROJECT_kotlin.compiler.execution.strategy": "in-process"
     container:
       image: cimg/android:${{ inputs.android-image-version }}
     defaults:

--- a/.github/workflows/android_library_artifactory.yml
+++ b/.github/workflows/android_library_artifactory.yml
@@ -67,6 +67,7 @@ jobs:
     runs-on: ${{ fromJSON(inputs.runs-on) }}
     env:
       GRADLE_OPTS: "-Dorg.gradle.workers.max=8 -Dorg.gradle.daemon=false"
+      CMAKE_BUILD_PARALLEL_LEVEL: 8
       "ORG_GRADLE_PROJECT_kotlin.compiler.execution.strategy": "in-process"
     container:
       image: cimg/android:${{ inputs.android-image-version }}


### PR DESCRIPTION
## Summary

- Cap Gradle workers at 8 for Gradle-running jobs that default to `k8s-runner`.
- Keep the Gradle daemon enabled for the multi-task code-quality job.
- Disable the daemon for the other targeted k8s Gradle jobs.
- Run the Kotlin compiler in-process for all targeted k8s Gradle jobs.
- Leave Docker and self-hosted workflows unchanged.

## Validation

- Checked the workflow diff for whitespace errors.
- Verified the worker, daemon, and Kotlin compiler settings across targeted jobs and exclusions.