### PR TITLE
Update Gradle cache action to v3.0.3

### DIFF
--- a/.github/actions/gradle-cache-setup/action.yml
+++ b/.github/actions/gradle-cache-setup/action.yml
@@ -10,7 +10,7 @@ runs:
   using: composite
   steps:
     - name: Gradle Cache
-      uses: burrunan/gradle-cache-action@v3.0.2
+      uses: burrunan/gradle-cache-action@v3.0.3
       with:
         job-id: ${{ inputs.job-id }}
         gradle-dependencies-cache-key: |


### PR DESCRIPTION
Updates the reusable Gradle cache composite action to use `burrunan/gradle-cache-action@v3.0.3`.